### PR TITLE
Added missing html end tag

### DIFF
--- a/firelynetsdk/parsing/poco-parsing.rst
+++ b/firelynetsdk/parsing/poco-parsing.rst
@@ -21,7 +21,7 @@ First, let us parse a bit of XML representing a FHIR Patient into the correspond
 
 .. code-block:: csharp
     
-    var xml = "<Patient xmlns='http://hl7.org/fhir'><active value='true'></Patient>";
+    var xml = "<Patient xmlns='http://hl7.org/fhir'><active value='true'/></Patient>";
     var parser = new FhirXmlParser();
 
     try


### PR DESCRIPTION
The "active" element was missing an end tag, meaning this sample code did not work as-is.