### PR TITLE
Fix firelyserver breadcrumb, remove obsolete

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ _build/
 /.vs/firely-docs/config/applicationhost.config
 /.vs/VSWorkspaceState.json
 venv
+*.code-workspace

--- a/_templates/breadcrumbs.html
+++ b/_templates/breadcrumbs.html
@@ -4,23 +4,11 @@
 
   <div><a href="https://www.devdays.com"><img src="{{ pathto('_static/images/banner.png', 1) }}" alt="FHIR DevDays banner"/></a></div>
   <hr/>
-	{% if _('firelynetsdk') in pagename %}
-		<li class="wy-breadcrumbs-api"><a href="{{ pathto(master_doc) }}">{{ _('Firely Docs') }}</a> &raquo;</li>
-	{% else %}
-		<li><a href="{{ pathto(master_doc) }}">{{ _('Firely Docs') }}</a> &raquo;</li>
-	{% endif %}
+	<li><a href="{{ pathto(master_doc) }}">{{ _('Firely Docs') }}</a> &raquo;</li>
 	{% for doc in parents %}
 		{% if loop.index == 1 %}
-			{% if _('simplifier') in pagename %}
-				<li><a href="{{ doc.link|e }}">Simplifier</a> &raquo;</li>
-			{% elif _('forge') in pagename %}
-				<li><a href="{{ doc.link|e }}">Forge</a> &raquo;</li>
-			{% elif _('vonk') in pagename %}
-				<li><a href="{{ doc.link|e }}">Vonk</a> &raquo;</li>
-			{% elif _('firelynetsdk') in pagename %}
-				<li><a href="{{ doc.link|e }}">SDK</a> &raquo;</li>
-			{% elif _('firelyterminal') in pagename %}
-				<li><a href="{{ doc.link|e }}">Firely Terminal</a> &raquo;</li>
+			{% if _('firelyserver') in pagename %}
+				<li><a href="{{ doc.link|e }}">Firely Server</a> &raquo;</li>
 			{% elif _('mappingengine') in pagename %}
 				<li><a href="{{ doc.link|e }}">FHIR Mapper</a> &raquo;</li>
 			{% elif _('vonkloader') in pagename %}
@@ -31,24 +19,4 @@
 		{% endif %}
 	{% endfor %}
     <li>{{ title }}</li>
-{% endblock %}
-
-<!-- Add navigation to GitHub for Firely .Net SDK docs, and include Azure DevOps status -->
-{% block breadcrumbs_aside %}
-	{% if hasdoc(pagename) %}
-		{% if _('firelynetsdk') in pagename %}
-			<li class="wy-breadcrumbs-aside">
-				<div class="wy-control-no-input">
-					STU3: <a href="https://dev.azure.com/firely/firely-net-sdk/_build?view=buildsHistory&definitionId=14"><img src="https://dev.azure.com/firely/firely-net-sdk/_apis/build/status/Continuous%20Build?branchName=develop-stu3"/></a>
-					R4: <a href="https://dev.azure.com/firely/firely-net-sdk/_build?view=buildsHistory&definitionId=14"><img src="https://dev.azure.com/firely/firely-net-sdk/_apis/build/status/Continuous%20Build?branchName=develop-r4"/></a></br>
-					<a href="https://github.com/FirelyTeam/firely-net-sdk">
-						<svg version="1.1" width="12" height="12" viewBox="0 0 16 16" class="octicon octicon-mark-github" aria-hidden="true">
-							<path fill-rule="evenodd" d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8z"/>
-						</svg>
-						 View source on GitHub
-					</a>
-				</div>
-			</li>
-		{% endif %}
-	{% endif %}
 {% endblock %}


### PR DESCRIPTION
Breadcrumb wasn't updated from Vonk to Firely Server. Updating for the time it still lives in main docs.

Removing obsolete parts from breadcrumbs template for already migrated docs.