### PR TITLE
Align structure map logical IDs with persist option

### DIFF
--- a/mappingengine/runningtransforms/runningtransforms.rst
+++ b/mappingengine/runningtransforms/runningtransforms.rst
@@ -7,7 +7,7 @@ Once your transforms are setup (:ref:`setup_transforms`), you can run your data 
 
 To do so, ``POST http(s)://<firely-server-endpoint>/administration/StructureMap/<logical id>/$transform`` with content to transform as the resource body. Make sure to set the ``Content-Type`` to either ``application/json`` or ``application/xml`` accordingly.
 
-For the example we've been working with so far, ``POST http://localhost:4080/administration/StructureMap/tutorial/$transform`` with a `sample resource <https://simplifier.net/fhirmapper/FakeInpatientDrugChart-example/~json>`_ as the body.
+For the example we've been working with so far, ``POST http://localhost:4080/administration/StructureMap/FHIRMapperTutorial/$transform`` with a `sample resource <https://simplifier.net/fhirmapper/FakeInpatientDrugChart-example/~json>`_ as the body.
 
 Simplified sample call:
 

--- a/mappingengine/transformsetup/mappingfile.rst
+++ b/mappingengine/transformsetup/mappingfile.rst
@@ -18,7 +18,7 @@ The FHIR Mapper operates on a StructureMap resource, so let's convert the mappin
 
 2. ``POST http(s)://<firely-server-endpoint>/administration/StructureMap`` with the resulting ``StructureMap``, or ``PUT`` to a unique ID. Make sure you don't make duplicates of the StructureMap on the server - so always use ``PUT`` to update the existing one afterwards. Note down logical ID of your map.
 
-  2.1. In our example, add ``"id": "tutorial",`` to the StructureMap received in step 1 and upload it to ``http://localhost:4080/administration/StructureMap/tutorial``. Thus ``tutorial`` is the logical ID we're working with.
+  2.1. In our example, add ``"id": "tutorial",`` to the StructureMap received in step 1 and upload it to ``http://localhost:4080/administration/StructureMap/FHIRMapperTutorial``. Thus ``FHIRMapperTutorial`` is the logical ID we're working with.
   
 .. note::
 


### PR DESCRIPTION
If you use the `persist` option, your logical ID will be `FHIRMapperTutorial` and not `tutorial`. Aligning the two so it's not more difficult than it should be!